### PR TITLE
Fix problems with Path and Shortcodes

### DIFF
--- a/piwigomedia.php
+++ b/piwigomedia.php
@@ -29,7 +29,7 @@ function register_piwigomedia_tinymce_plugin($plugin_array) {
 function register_piwigomedia_plugin() {
     load_plugin_textdomain('piwigomedia', null, 'piwigomedia/languages/');
     
-    if ((current_user_can('edit_posts') && current_user_can('edit_pages')) || get_user_option('rich_editing') == 'true') {
+    if (current_user_can('edit_posts') || current_user_can('edit_pages') || get_user_option('rich_editing') == 'true') {
         add_filter('mce_buttons', 'register_piwigomedia_tinymce_button');
         add_filter('mce_external_plugins', 'register_piwigomedia_tinymce_plugin');
     }

--- a/piwigomedia.php
+++ b/piwigomedia.php
@@ -27,15 +27,12 @@ function register_piwigomedia_tinymce_plugin($plugin_array) {
 }
 
 function register_piwigomedia_plugin() {
-    if (!current_user_can('edit_posts') && !current_user_can('edit_pages'))
-        return;
-    if (get_user_option('rich_editing') != 'true')
-        return;
-
     load_plugin_textdomain('piwigomedia', null, 'piwigomedia/languages/');
-
-    add_filter('mce_buttons', 'register_piwigomedia_tinymce_button');
-    add_filter('mce_external_plugins', 'register_piwigomedia_tinymce_plugin');
+    
+    if ((current_user_can('edit_posts') && current_user_can('edit_pages')) || get_user_option('rich_editing') == 'true') {
+        add_filter('mce_buttons', 'register_piwigomedia_tinymce_button');
+        add_filter('mce_external_plugins', 'register_piwigomedia_tinymce_plugin');
+    }
 
     add_shortcode('pwg-image', 'pwg_image');
     add_shortcode('pwg-category', 'pwg_category');

--- a/piwigomedia.php
+++ b/piwigomedia.php
@@ -49,7 +49,7 @@ function register_piwigomedia_plugin() {
 function load_piwigomedia_headers() {
     wp_enqueue_style('piwigomedia', WP_PLUGIN_URL.'/piwigomedia/css/piwigomedia.css', false, '1.0', 'all');
     wp_enqueue_style('galleria', WP_PLUGIN_URL.'/piwigomedia/js/galleria/themes/classic/galleria.classic.css', false, '1.0', 'all');
-    wp_register_script('galleria-min', plugins_url( '/js/galleria/galleria-1.2.9.min.js', __FILE__ ) );
+    wp_register_script('galleria-min', WP_PLUGIN_URL.'/piwigomedia/js/galleria/galleria-1.2.9.min.js', __FILE__ );
     wp_enqueue_script('galleria-min');
 }
 
@@ -137,7 +137,7 @@ if (count($res->result->images) > 0) {
 	}
 	$out .= "</div>";
 }
-    return "$out <script>Galleria.loadTheme('wp-content/plugins/piwigomedia/js/galleria/themes/classic/galleria.classic.min.js');Galleria.run('#piwigomedia-gallery-$id');</script>";
+    return "$out <script>Galleria.loadTheme('".WP_PLUGIN_URL."'/piwigomedia/js/galleria/themes/classic/galleria.classic.min.js');Galleria.run('#piwigomedia-gallery-$id');</script>";
 }
 
 

--- a/utils.php
+++ b/utils.php
@@ -29,8 +29,8 @@ function pwm_curl_post($url, array $post = NULL, array $options = array())
         CURLOPT_FORBID_REUSE => 1,
         CURLOPT_TIMEOUT => 10,
         CURLOPT_POSTFIELDS => http_build_query($post),
-        CURLOPT_SSL_VERIFYPEER => false,
-        CURLOPT_SSL_VERIFYHOST => false
+        CURLOPT_SSL_VERIFYPEER => 1,
+        CURLOPT_SSL_VERIFYHOST => 2
     );
 
     $ch = curl_init();
@@ -51,8 +51,8 @@ function pwm_curl_get($url, array $get = NULL, array $options = array())
         CURLOPT_HEADER => 0,
         CURLOPT_RETURNTRANSFER => TRUE,
         CURLOPT_TIMEOUT => 10,
-        CURLOPT_SSL_VERIFYPEER => false,
-        CURLOPT_SSL_VERIFYHOST => false
+        CURLOPT_SSL_VERIFYPEER => 1,
+        CURLOPT_SSL_VERIFYHOST => 2
     );
 
     $ch = curl_init();


### PR DESCRIPTION
When using Piwigomedia on pages with permalinks containing a '/', galleria.classic.min.js couldn't be found.

Additionally shortcodes were only working for users with edit permissions because of the old if-statements.

I also enabled the CURLOPTs to check the certificates.